### PR TITLE
vercel-ignore-build-step.shを追加

### DIFF
--- a/vercel-ignore-build-step.sh
+++ b/vercel-ignore-build-step.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "develop" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
diff --git a/vercel-ignore-build-step.sh b/vercel-ignore-build-step.sh new file mode 100644
index 0000000..1e51b70
--- /dev/null
+++ b/vercel-ignore-build-step.sh
@@ -0,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF" +
+if [[ "$VERCEL_GIT_COMMIT_REF" == "develop" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1; +
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0; +fi
\ No newline at end of file